### PR TITLE
Provide compatibility with Foliant 1.0.8.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 foliant-docs
+Copyright (c) 2018 foliant-docs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,16 @@
+# 1.0.4 (under development)
+
+-   Provide compatibility with Foliant 1.0.8.
+
 # 1.0.3
 
-- Add slate preprocessor which copies the images outside src into the slate project.
+-   Add slate preprocessor which copies the images outside src into the slate project.
 
 # 1.0.2
 
-- Rename shards_path param to shards. It now accepts string or list.
-- Fix no header param
+-   Rename shards_path param to shards. It now accepts string or list.
+-   Fix no header param.
 
 # 1.0.1
 
--    Remove flatten. First chapter goes to index.html.md; all the rest go into the includes.
+-   Remove flatten. First chapter goes to index.html.md; all the rest go into the includes.

--- a/foliant/backends/slate.py
+++ b/foliant/backends/slate.py
@@ -158,7 +158,7 @@ class Backend(BaseBackend):
                 stderr=STDOUT)
 
     def make(self, target: str) -> str:
-        with spinner(f'Making {target}', self.logger, self.quiet):
+        with spinner(f'Making {target}', self.logger, self.quiet, self.debug):
             try:
                 chapters = self._chapters.paths_g
                 src_path = self._slate_tmp_dir / 'source/'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license='MIT',
     platforms='any',
     install_requires=[
-        'foliant>=1.0.4',
+        'foliant>=1.0.8',
         'PyYAML'
     ],
     classifiers=[


### PR DESCRIPTION
Use the updated `spinner()` method.