### PR TITLE
fix: error due to missing slatedocs repository

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.9
+
+- Fix: error due to missing slatedocs repository
+
 # 1.0.8
 
 - Support meta 1.3

--- a/foliant/backends/slate.py
+++ b/foliant/backends/slate.py
@@ -12,7 +12,7 @@ from foliant.backends.base import BaseBackend
 from distutils.dir_util import copy_tree, remove_tree
 from pathlib import PosixPath, Path
 
-SLATE_REPO = 'https://github.com/lord/slate.git'
+SLATE_REPO = 'https://github.com/TOsmanov/slate.git'
 
 
 def copy_replace(src: str, dst: str):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='1.0.8',
+    version='1.0.9',
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     url='https://github.com/foliant-docs/foliantcontrib.slate',


### PR DESCRIPTION

---
## EntelligenceAI PR Summary 
 This PR updates the Slate backend to use a forked repository instead of the original source.
- Changed repository URL constant from 'lord/slate' to 'TOsmanov/slate' in the Slate backend
- No functional logic changes to the backend implementation
- Enables access to potentially maintained fork with specific features or fixes 

